### PR TITLE
Allow custom commands in evil-mc-known-command-p

### DIFF
--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -287,6 +287,7 @@ which will be used if no entry matching the current state is found.")
 (defun evil-mc-known-command-p (cmd)
   "True if CMD is a supported command."
   (or (not (null (assq cmd evil-mc-known-commands)))
+      (not (null (assq cmd evil-mc-custom-known-commands)))
       (eq (evil-get-command-property cmd :repeat) 'motion)))
 
 (defun evil-mc-has-cursors-p ()


### PR DESCRIPTION
Defining custom known commands in evil-mc-custom-known-commands didn't
make any effect because it was ignored by evil-mc-known-command-p.  Now
it is fixed.