### PR TITLE
add evil-mc functions to create cursor at point and move to next/previous line

### DIFF
--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -344,6 +344,22 @@ and optionally CREATE a cursor at point."
   (evil-mc-run-cursors-before)
   (evil-mc-make-cursor-at-pos (point)))
 
+(evil-define-command evil-mc-make-cursor-move-next-line ()
+  "Create a cursor at point and move to next line."
+  :repeat ignore
+  :evil-mc t
+  (evil-mc-run-cursors-before)
+  (evil-mc-make-cursor-at-pos (point))
+  (next-line))
+
+(evil-define-command evil-mc-make-cursor-move-prev-line ()
+  "Create a cursor at point and move to previous line."
+  :repeat ignore
+  :evil-mc t
+  (evil-mc-run-cursors-before)
+  (evil-mc-make-cursor-at-pos (point))
+  (previous-line))
+
 (evil-define-command evil-mc-make-and-goto-first-cursor ()
   "Make a cursor at point and move point to the cursor with the lowest position."
   :repeat ignore

--- a/evil-mc.el
+++ b/evil-mc.el
@@ -62,6 +62,8 @@
                 ("grf" . evil-mc-make-and-goto-first-cursor)
                 ("grl" . evil-mc-make-and-goto-last-cursor)
                 ("grh" . evil-mc-make-cursor-here)
+                ("grj" . evil-mc-make-cursor-move-next-line)
+                ("grk" . evil-mc-make-cursor-move-prev-line)
                 ("M-n" . evil-mc-make-and-goto-next-cursor)
                 ("grN" . evil-mc-skip-and-goto-next-cursor)
                 ("M-p" . evil-mc-make-and-goto-prev-cursor)


### PR DESCRIPTION
Hi, this is a pull request and a proposal to add functions (and keybindings) to allow a user to create a new cursor at the current point and move the main cursor up (grk) or down (grj) in a single stroke. 

My motivation for this is to solve a common issue I have that is cumbersome to do otherwise with evil-mc. 

I frequently have a list of different words where I want to build a set of statements around each word. In order to get a cursor at the start of each of the words to edit them simulaneously, I have to pause cursors, make cursor at point, move down, for each word, then resume cursors at the last one. This results in a ton of key presses, especially with three key chords.

With this update a user would simply need to press 'grj' to make a cursor at the current point and move the main cursor down a line, and conversely 'grk' to move it up a line. This will drastically cut down the effort to support a fairly common scenario.

Thanks!