### PR TITLE
Fake bar cursors

### DIFF
--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -36,11 +36,6 @@
     (overlay-put overlay 'priority evil-mc-cursor-overlay-priority)
     overlay))
 
-(defface evil-mc-cursor-bar-face
-  `((t (:height 1 :background ,(car evil-insert-state-cursor))))
-  "The face used for fake cursors if the cursor-type is bar"
-  :group 'evil-mc)
-
 (defun evil-mc-cursor-is-bar ()
   "returns true if the cursor is a bar"
   (cond ((equalp cursor-type 'bar) t)

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -11,6 +11,7 @@
 (require 'evil-mc-vars)
 (require 'evil-mc-cursor-state)
 (require 'evil-mc-region)
+(require 'evil)
 
 (defun evil-mc-get-cursor-face ()
   "Get the current cursor face."

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -11,7 +11,6 @@
 (require 'evil-mc-vars)
 (require 'evil-mc-cursor-state)
 (require 'evil-mc-region)
-(require 'evil)
 
 (defun evil-mc-get-cursor-face ()
   "Get the current cursor face."

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -35,18 +35,33 @@
     (overlay-put overlay 'priority evil-mc-cursor-overlay-priority)
     overlay))
 
+(defface evil-mc-cursor-bar-face
+  `((t (:height 1 :background ,(car evil-insert-state-cursor))))
+  "The face used for fake cursors if the cursor-type is bar"
+  :group 'evil-mc)
+
+(defun evil-mc-cursor-is-bar ()
+  "returns true if the cursor is a bar"
+  (cond ((equalp cursor-type 'bar) t)
+	((when (listp cursor-type) (equalp (car cursor-type) 'bar)) t)
+	(t nil)))
+
 (defun evil-mc-cursor-overlay-at-eol (pos)
   "Make a cursor overlay at POS assuming pos is at the end of line."
   (let ((overlay (evil-mc-cursor-overlay pos pos))
         (face (evil-mc-get-cursor-face)))
-    (overlay-put overlay 'after-string (propertize " " 'face face))
+    (if (evil-mc-cursor-is-bar)
+	(overlay-put overlay 'before-string (propertize "|" 'face 'evil-mc-cursor-bar-face))
+      (overlay-put overlay 'after-string (propertize " " 'face face)))
     overlay))
 
 (defun evil-mc-cursor-overlay-inline (pos)
   "Make a cursor overlay at POS assuming pos is not at the end of line."
   (let ((overlay (evil-mc-cursor-overlay pos (1+ pos)))
         (face (evil-mc-get-cursor-face)))
-    (overlay-put overlay 'face face)
+    (if (evil-mc-cursor-is-bar)
+	(overlay-put overlay 'before-string (propertize "|" 'face 'evil-mc-cursor-bar-face))
+      (overlay-put overlay 'face face))
     overlay))
 
 (defun evil-mc-cursor-overlay-at-pos (&optional pos)

--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -23,6 +23,11 @@
   "The face used for fake regions"
   :group 'evil-mc)
 
+(defface evil-mc-cursor-bar-face
+  `((t (:height 1 :background ,(car evil-insert-state-cursor))))
+  "The face used for fake cursors if the cursor-type is bar"
+  :group 'evil-mc)
+
 (defcustom evil-mc-cursor-overlay-priority 201
   "The priority of the fake cursors overlay."
   :type 'integer

--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -5,6 +5,7 @@
 ;; This file contains variables used by evil-mc
 
 (require 'evil-mc-known-commands)
+(require 'evil-states)
 
 ;;; Code:
 


### PR DESCRIPTION
I more or less copied the changes in magnars multiple-cursors for this.


It introduces a function `evil-mc-cursor-is-bar` which is just copied from magnars mc.


Further it introduces a face `evil-mc-cursor-bar-face`, that uses the background color of evil-insert-state-cursor (this might be not optimal, but i guess most evil-mode users use the bar cursor for insert state).


the functions `evil-mc-cursor-overlay-at-eol` and `evil-mc-cursor-overlay-inline` are checking if the cursor is a bar and if so, they use the `evil-mc-cursor-bar-face`.

There is probably a better way to deside the background color of the new face (or without defining a new face) like your code does for the background color of the regular cursors, but my elisp knowledge is not that great, and this is working so far.
