### PR TITLE
Don't use obsoleted function

### DIFF
--- a/evil-mc-scratch.el
+++ b/evil-mc-scratch.el
@@ -31,7 +31,7 @@
   (interactive)
   (evil-mc-execute-for-all-cursors
    (lambda (cursor)
-     (insert-string
+     (insert
       (format-time-string "%d/%m/%Y" (current-time))))))
 
 (provide 'evil-mc-scratch)


### PR DESCRIPTION
insert-string is a obsolted function and removed from development Emacs(https://github.com/emacs-mirror/emacs/commit/949144c279e07e870ef4ee2de38787420b749828)