### PR TITLE
Add spacemacs-evil/evil-mc-paste-* to known commands

### DIFF
--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -229,6 +229,8 @@
 
     ;; spacemacs
     (spacemacs/smart-closing-parenthesis  . ((:default . evil-mc-execute-default-call)))
+    (spacemacs-evil/evil-mc-paste-after . ((:default . evil-mc-execute-default-evil-paste)))
+    (spacemacs-evil/evil-mc-paste-before . ((:default . evil-mc-execute-default-evil-paste)))
 
     ;; auctex
     (TeX-insert-backslash . ((:default . evil-mc-execute-default-call-with-count)))


### PR DESCRIPTION
This will help spacemacs users to user evil-paste even when transient-paste state is enabled mentioned at #53 . This PR is paired with syl20bnr/spacemacs#8620