### PR TITLE
Renamed to `spacemacs/evil-mc-paste-*`

### DIFF
--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -229,8 +229,8 @@
 
     ;; spacemacs
     (spacemacs/smart-closing-parenthesis  . ((:default . evil-mc-execute-default-call)))
-    (spacemacs-evil/evil-mc-paste-after . ((:default . evil-mc-execute-default-evil-paste)))
-    (spacemacs-evil/evil-mc-paste-before . ((:default . evil-mc-execute-default-evil-paste)))
+    (spacemacs/evil-mc-paste-after . ((:default . evil-mc-execute-default-evil-paste)))
+    (spacemacs/evil-mc-paste-before . ((:default . evil-mc-execute-default-evil-paste)))
 
     ;; auctex
     (TeX-insert-backslash . ((:default . evil-mc-execute-default-call-with-count)))


### PR DESCRIPTION
As per request from syl20bnr/spacemacs#8620 the function names were renamed from
`spacemacs-evil/evil-mc-paste-*` to `spacemacs/evil-mc-paste-*`