### PR TITLE
Add typescript-insert-and-indent to known commands

### DIFF
--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -240,6 +240,9 @@
     (TeX-insert-sub-or-superscript . ((:default . evil-mc-execute-default-call-with-count)))
     (TeX-insert-dollar . ((:default . evil-mc-execute-default-call-with-count)))
 
+    ;; tide
+    (typescript-insert-and-indent . ((self-insert-command . evil-mc-execute-default-call-with-count)))
+
     ;; evil-cleverparens
     (evil-cp-append ; a
      (:default . evil-mc-execute-default-call-with-count))


### PR DESCRIPTION
[tide](https://github.com/ananthakumaran/tide) is a TypeScript dev env in Emacs. It overrides `{`, `}`, `;`, etc in the insert mode and thus they doesn't work with extra cursors.

This is the information of `}` input in the insert mode.

```
} runs the command typescript-insert-and-indent, which is an interactive
compiled Lisp function in `typescript-mode.el'.

It is bound to ,, ;, :, ), (, }, {.

(typescript-insert-and-indent KEY)

Run the command bound to KEY, and indent if necessary.
Indentation does not take place if point is in a string or
comment.
```

Because of the `KEY`, maybe, I couldn't make it work with `:default`, and just used `self-insert-command` as we may not expect lines to be auto-indented when working with multiple cursors.

Please leave comments if there is a better way to do this.

Thanks for the great package!