### PR TITLE
Rewrite mode line text with 4 variables

### DIFF
--- a/README.org
+++ b/README.org
@@ -143,6 +143,42 @@ Here's a detailed list of all commands used to create, navigate through, or dele
   ;; this hook runs just after the last cursor is deleted
   #+END_SRC
 
+*** Mode line text and colors
+There are 4 variables, that can change the mode lines text, and its color.
+
+**** Only one cursor
+The ~emc~ text can be hidden, by setting this variable to ~nil~.
+(default: ~t~)
+#+BEGIN_SRC
+(setq evil-mc-one-cursor-show-mode-line-text t)
+#+END_SRC
+
+**** Two or more cursors, resumed (unpaused)
+The resumed mode line text, can have two different colors:
+- The cursors color, when this variable is ~t~.
+- The default colors, when this variable is ~nil~.
+(default: ~t~)
+#+BEGIN_SRC
+(setq evil-mc-mode-line-text-cursor-color t)
+#+END_SRC
+
+**** Two or more cursors, paused
+The ~(paused)~ text can be hidden, by setting this variable to ~nil~.
+(default: ~t~)
+#+BEGIN_SRC
+(setq evil-mc-mode-line-text-paused t)
+#+END_SRC
+
+The paused mode line text can have three different colors:
+- Inverse colors, when the inverse colors variable is ~t~.
+- Cursors color, when the inverse colors variable is ~nil~, and the cursor color variable is ~t~.
+- Default colors, when both the inverse and cursor color variables are ~nil~.
+(default: ~t~, for both the inverse and cursor variables)
+#+BEGIN_SRC
+(setq evil-mc-mode-line-text-inverse-colors t)
+(setq evil-mc-mode-line-text-cursor-color t)
+#+END_SRC
+
 *** Notes
 - Most evil motions and operators are supported but not every single command will work. 
 - If the cursors don't seem to work during a command, either the command is

--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -131,6 +131,18 @@
 (evil-define-local-var evil-mc-paused-modes nil
   "List of temporarily disabled minor modes.")
 
+(evil-define-local-var evil-mc-one-cursor-show-mode-line-text t
+  "Show mode line text when there's only one cursor.")
+
+(evil-define-local-var evil-mc-mode-line-text-paused t
+  "Show (paused) text in the mode line.")
+
+(evil-define-local-var evil-mc-mode-line-text-inverse-colors t
+  "Show mode line text with inverse colors.")
+
+(evil-define-local-var evil-mc-mode-line-text-cursor-color t
+  "Show mode line text with the cursor color.")
+
 (defun evil-mc-known-command-p (cmd)
   "True if CMD is a supported command."
   (or (not (null (assq cmd evil-mc-known-commands)))


### PR DESCRIPTION
Currently the mode line text looks like this:

![current-evil-mc-mode-line](https://cloud.githubusercontent.com/assets/13420573/26351037/0597a50c-3fb6-11e7-99c0-1326d5919a99.png)

With the variables in this PR, the mode line can look like this:

![evil-mc-mode-line-variables](https://cloud.githubusercontent.com/assets/13420573/26351064/218565ec-3fb6-11e7-800d-83d11fdad65d.gif)

This rewrites the mode line text assignment, with 4 variables:
```
evil-mc-one-cursor-show-mode-line-text
evil-mc-mode-line-text-paused
evil-mc-mode-line-text-inverse-colors
evil-mc-mode-line-text-cursor-color
```

**When there's only one cursor:**
text: show/hide "emc"

**When there are two or more cursors, resumed (unpaused):**
colors: cursor or default

**When there are two or more cursors, paused:**
text: show/hide "(paused)"
colors: inverse, cursor or default

**All 4 variables are enabled by default, resulting in:**
one cursor:
text: "emc" shown

two cursors, resumed:
color: cursor

two cursors, paused:
text: "(paused)" shown
colors: inverse

This also updates README.org, with a "mode line text and colors" section,
that explains how the variables work.

**This PR resolves:**
[Variable, if single cursor, hide mode line "emc" text #58](https://github.com/gabesoft/evil-mc/issues/58)

If this PR is accepted, then i can make a PR to the Spacemacs repository, that replaces the current 
`evil-mc-mode-line` reassignment. So that it only uses the variable to hide the "emc" text.

### Questions:
#### Q1:
The `,(propertize ...` command had a `,` comma before it. But in this rewrite, a string variable is propertized, and when a preceding comma is used, then the minibuffer shows:
> Symbol’s value as variable is void: mode-line-text

It seems to work fine without it, but is the comma needed?

#### Q2:
This line:
`(put 'evil-mc-mode-line 'risky-local-variable t)`

is called after the `(defcustom evil-mc-mode-line ...` assignment, but i noticed in the `defcustom` doc-string that it says:
> :risky	Set SYMBOL’s ‘risky-local-variable’ property to VALUE.

I don't know if they are equivalent. But I removed the `put ... risky-local-variable t`, command and replaced it with `:risky t` at the end of the `evil-mc-mode-line` assignment.

Is it fine to replace it or should i change it back?

#### Q3:
I also noticed in the `defcustom` doc-string, that it says:
> :type   VALUE should be a widget type for editing the symbol’s value.
Every ‘defcustom’ should specify a value for this keyword.

If a `:type` entry should be added, what should it's value be?

### A small auto indent issue
I indented the last two of these lines manually:
```
                                  'face '(:inherit cursor
                                          :foreground "black"
                                          :distant-foreground "white")))
```
because when they are aligned automatically, then they look like this:
```
                                  'face '(:inherit cursor
                                                   :foreground "black"
                                                   :distant-foreground "white")))

```
there's a discussion about his issue here:
https://emacs.stackexchange.com/questions/10230/how-to-indent-keywords-aligned

I just thought that I should mention it, so that it won't be a surprise in the future, if `evil-mc.el` ever is auto indented, and those lines appear in the diff.