### PR TITLE
Add command to undo last added cursor

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@ in short, ~C-n~ / ~C-p~ are used for creating cursors, and ~M-n~ / ~M-p~
 are used for cycling through cursors. The commands that create cursors wrap around; but, 
 the ones that cycle them do not. 
 To skip creating a cursor forward use ~C-t~ or ~grn~ and backward ~grp~. 
-Finally use ~gru~ to remove all cursors.
+Finally use ~gru~ to "undo" the last added cursor, and ~grq~ to remove all cursors.
 
 For an example of setting up *evil-mc* see this [[https://github.com/gabesoft/evil-mc/blob/master/evil-mc-setup.el][setup file]]
 **** Commands
@@ -71,6 +71,9 @@ Here's a detailed list of all commands used to create, navigate through, or dele
 
 (evil-mc-undo-all-cursors)
 ;; Remove all cursors.
+
+(evil-mc-undo-last-added-cursor)
+;; Remove the last added cursor and move point to its position.
 
 (evil-mc-make-and-goto-next-match)
 ;; Make a cursor at point, and go to the next match of the 

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -220,6 +220,21 @@ Return the deleted cursor."
                           evil-mc-cursor-list)))
     found))
 
+(defun evil-mc-undo-last-added-cursor ()
+  "Delete the latest added cursor from `evil-mc-cursor-list' and remove its overlay.
+Move the point to its position."
+  (interactive)
+  (when (evil-mc-has-cursors-p)
+    (let ((latest-cursor nil)
+          (order 0))
+      (dolist (c evil-mc-cursor-list)
+        (if (> (evil-mc-get-cursor-property c 'order) order)
+            (setq latest-cursor c)))
+      (goto-char (evil-mc-get-cursor-start latest-cursor))
+      (setq evil-mc-cursor-list (remove latest-cursor evil-mc-cursor-list))
+      (evil-mc-delete-cursor latest-cursor))))
+
+
 (defun evil-mc-find-prev-cursor (&optional pos)
   "Find the cursor closest to POS when searching backwards."
   (let ((prev nil) (pos (or pos (point))))

--- a/evil-mc.el
+++ b/evil-mc.el
@@ -79,7 +79,8 @@
 (defvar evil-mc-key-map
   (let ((map (make-sparse-keymap))
         (keys '(("grm" . evil-mc-make-all-cursors)
-                ("gru" . evil-mc-undo-all-cursors)
+                ("gru" . evil-mc-undo-last-added-cursor)
+                ("grq" . evil-mc-undo-all-cursors)
                 ("grs" . evil-mc-pause-cursors)
                 ("grr" . evil-mc-resume-cursors)
                 ("grf" . evil-mc-make-and-goto-first-cursor)

--- a/features/evil-mc-copy-paste.feature
+++ b/features/evil-mc-copy-paste.feature
@@ -168,7 +168,7 @@ Feature: Copy paste
     And I press "C-n"
     And I press "w"
     And I press "3yw"
-    And I press "gru"
+    And I press "grq"
     And I press "G"
     And I press "C-x r y"
     Then I should see:


### PR DESCRIPTION
This PR adds functionality of undoing the last added cursor, which is available in
other editors' multiple cursor implementations. This makes it possible to correct
the common mistake of creating too many cursors (e.g when hitting `C-n` past the
intended range), without having to start all over again.

Also changes the binding of "gru" to undo the very last added cursor instead
of deleting all cursors, in line with the meaning of "u = undo last action" in
evil mode.

The previous binding of `evil-mc-undo-all-cursors` is moved to "grq" ("quit")