### PR TITLE
Added outshine insert support

### DIFF
--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -217,6 +217,9 @@
     (orgtbl-hijacker-command-109 . ((:default . evil-mc-execute-default-call-with-count)))
     (org-delete-backward-char . ((:default . evil-mc-execute-default-call-with-count)))
 
+     ;; Outshine
+    (outshine-self-insert-command . ((:default . evil-mc-execute-default-call-with-count)))
+
     ;; unimpaired
     (unimpaired/paste-above . ((:default . evil-mc-execute-default-call)))
     (unimpaired/paste-below . ((:default . evil-mc-execute-default-call)))


### PR DESCRIPTION
Right now on master if you enable outshine mode, the cloned cursors can't insert anything because outshine has it's own self-insert-command. This adds that command to the list of allowed commands.

Seems like someone at #22 was affected by this problem aswell.