### PR TITLE
Make cursor on every line of visual selection

### DIFF
--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -460,6 +460,57 @@ cursor that is already there."
               (goto-char pt)
               (evil-mc-make-cursor-here))))))))
 
+(defun evil-mc-make-cursor-in-visual-selection-block (column)
+  "Create cursors at COLUMN column."
+  (evil-visual-rotate 'upper-left)
+  (dotimes (num (- (count-lines evil-visual-beginning evil-visual-end) 1))
+    (if (not (= (move-to-column column) column))
+        (progn
+          (indent-to-column column)
+          (move-to-column column)))
+    (evil-mc-run-cursors-before)
+    (evil-mc-make-cursor-at-pos (point))
+    (forward-line))
+  (move-to-column column))
+
+(defun evil-mc-make-cursor-in-visual-selection (beg)
+  "If BEG is non-nil, create cursors at beginning of line."
+  (evil-visual-rotate 'upper-left)
+  (dotimes (num (- (count-lines evil-visual-beginning evil-visual-end) 1))
+    (evil-mc-run-cursors-before)
+    (evil-mc-make-cursor-at-pos
+     (if beg
+         (line-beginning-position)
+       (line-end-position)))
+    (forward-line))
+  (if beg
+      (beginning-of-line)
+    (end-of-line)))
+
+(evil-define-command evil-mc-make-cursor-in-visual-selection-beg ()
+  "Create cursor in beginning of every visually selected line.
+Acts like the I key in evil-visual-state."
+  :repeat ignore
+  :evil-mc t
+  (if (eq (evil-visual-type) 'block)
+      (evil-mc-make-cursor-in-visual-selection-block
+       (min (evil-column evil-visual-beginning)
+            (evil-column evil-visual-end)))
+    (evil-mc-make-cursor-in-visual-selection t))
+  (evil-insert-state))
+
+(evil-define-command evil-mc-make-cursor-in-visual-selection-end ()
+  "Create cursor at end of every visually selected line.
+Acts like the A key in evil-visual-state."
+  :repeat ignore
+  :evil-mc t
+  (if (eq (evil-visual-type) 'block)
+      (evil-mc-make-cursor-in-visual-selection-block
+       (max (evil-column evil-visual-beginning)
+            (evil-column evil-visual-end)))
+    (evil-mc-make-cursor-in-visual-selection nil))
+  (evil-insert-state))
+
 (evil-define-command evil-mc-make-cursor-move-next-line (count)
   "Create a cursor at point and move to next line."
   :repeat ignore

--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -217,9 +217,6 @@
     (orgtbl-hijacker-command-109 . ((:default . evil-mc-execute-default-call-with-count)))
     (org-delete-backward-char . ((:default . evil-mc-execute-default-call-with-count)))
 
-     ;; Outshine
-    (outshine-self-insert-command . ((:default . evil-mc-execute-default-call-with-count)))
-
     ;; unimpaired
     (unimpaired/paste-above . ((:default . evil-mc-execute-default-call)))
     (unimpaired/paste-below . ((:default . evil-mc-execute-default-call)))

--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -217,6 +217,9 @@
     (orgtbl-hijacker-command-109 . ((:default . evil-mc-execute-default-call-with-count)))
     (org-delete-backward-char . ((:default . evil-mc-execute-default-call-with-count)))
 
+     ;; Outshine
+    (outshine-self-insert-command . ((:default . evil-mc-execute-default-call-with-count)))
+
     ;; unimpaired
     (unimpaired/paste-above . ((:default . evil-mc-execute-default-call)))
     (unimpaired/paste-below . ((:default . evil-mc-execute-default-call)))


### PR DESCRIPTION
In evil/vi if you are in visual mode with a multi-line visual selection and press I or A, you are put into insert mode and when you exit, that insertion will be applied to every line in your visual selection.
This patch allows you to instead use multiple cursors to do this which allows for more advanced edits and somehow it seems to perform better than doing it the default way.
It seems like this was talked about in #43 and #22.

There is one minor bug I found that I can't bother solving right now however and that is if there is a tab where a cursor is supposed to be it will be put at the end of the tab. You would just need to make it break up the tab into spaces to fix this however.