### PR TITLE
Fix an error on before-cursors-setup hook

### DIFF
--- a/evil-mc-setup.el
+++ b/evil-mc-setup.el
@@ -28,7 +28,7 @@ Can be used to temporarily disable any functionality that doesn't
 play well with `evil-mc'."
   (mapc 'evil-mc-pause-smartchr-for-mode
         '(web-mode js2-mode java-mode (enh-ruby-mode . ruby-mode) css-mode))
-  (when (boundp whitespace-cleanup-disabled)
+  (when (boundp 'whitespace-cleanup-disabled)
     (setq whitespace-cleanup-disabled t)
     (push (lambda () (setq whitespace-cleanup-disabled nil)) evil-mc-custom-paused)))
 


### PR DESCRIPTION
## Description

Fix an error on before-cursors-setup hook, which occurs when `whitespace-cleanup-disabled` is not defined.

```
Debugger entered--Lisp error: (void-variable whitespace-cleanup-disabled)
  (boundp whitespace-cleanup-disabled)
  (if (boundp whitespace-cleanup-disabled) (progn (setq whitespace-cleanup-disabled t) (setq evil-mc-custom-paused (cons (function (lambda nil (setq whitespace-cleanup-disabled nil))) evil-mc-custom-paused))))
  evil-mc-before-cursors-setup-hook()
  run-hooks(evil-mc-before-cursors-created)
  evil-mc-cursors-before()
  evil-mc-run-cursors-before()
  evil-mc-make-cursor-move-by-line(1 nil)
  evil-mc-make-cursor-move-next-line(nil)
  funcall-interactively(evil-mc-make-cursor-move-next-line nil)
  call-interactively(evil-mc-make-cursor-move-next-line nil nil)
  command-execute(evil-mc-make-cursor-move-next-line)
```