### PR TITLE
Require cl-lib instead of cl

### DIFF
--- a/features/support/env.el
+++ b/features/support/env.el
@@ -11,7 +11,7 @@
 
 (add-to-list 'load-path evil-multiple-cursors-root-path)
 
-(require 'cl)
+(require 'cl-lib)
 (require 'evil)
 (require 'evil-surround)
 (require 'evil-numbers)


### PR DESCRIPTION
cl is deprecated as of Emacs 27.


----

#