### PR TITLE
Fix unknown interactive code problem

### DIFF
--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -7,6 +7,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'evil-types)
 (require 'evil-mc-common)
 (require 'evil-mc-vars)
 (require 'evil-mc-cursor-state)


### PR DESCRIPTION
In the emacs/native-comp branch, evil-mc-cursor-make.el fails to
compile, because:

Debugger entered--Lisp error: (user-error "Unknown interactive code: ‘<c>’")
  user-error("Unknown interactive code: `%s'" "<c>")
  evil-interactive-string("<c>")
  evil-interactive-form("<c>")
  apply(evil-interactive-form "<c>")

This PR fixes this error.