### PR TITLE
more evil-org support hlissner/doom-emacs#4484

### DIFF
--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -221,6 +221,12 @@
     (orgtbl-hijacker-command-109 . ((:default . evil-mc-execute-default-call-with-count)))
     (org-delete-backward-char . ((:default . evil-mc-execute-default-call-with-count)))
     (org-delete-char . ((:default . evil-mc-execute-default-call-with-count)))
+
+    ;; evil-org
+    (evil-org-insert-line . ((:default . evil-mc-execute-default-call-with-count)))
+    (evil-org-append-line . ((:default . evil-mc-execute-default-call-with-count)))
+    (evil-org-open-below . ((:default . evil-mc-execute-default-call-with-count)))
+    (evil-org-open-above . ((:default . evil-mc-execute-default-call-with-count)))
     (evil-org-delete-char . ((:default . evil-mc-execute-default-evil-delete)))
     (evil-org-delete-backward-char . ((:default . evil-mc-execute-default-evil-delete)))
 


### PR DESCRIPTION
Add support for several evil-org-mode functions by adding them to the variable ```evil-mc-known-commands```. 