### PR TITLE
evil-mc-command-record can handle new pre-read-key-sequence type, fix #131

### DIFF
--- a/evil-mc-command-record.el
+++ b/evil-mc-command-record.el
@@ -99,7 +99,8 @@
   "Save KEYS at PRE-NAME or POST-NAME according to FLAG."
   (cl-ecase flag
     (pre (evil-mc-add-command-property pre-name keys))
-    (post (evil-mc-add-command-property post-name keys))))
+    (post (evil-mc-add-command-property post-name keys))
+    (pre-read-key-sequence (evil-mc-add-command-property post-name keys))))
 
 (defun evil-mc-update-command-count (keys-vector)
   "Update the current command count with the last digit of KEYS-VECTOR."


### PR DESCRIPTION
in addition to pre and post types evil recently introduced pre-read-key-sequence

https://github.com/emacs-evil/evil/commit/2b2ba3cbeabe1f239b6b0ebdaddcb68dd158bd1f

fix #131