### PR TITLE
explicitly set lexical-binding to nil in all files

### DIFF
--- a/evil-mc-command-execute.el
+++ b/evil-mc-command-execute.el
@@ -1,4 +1,4 @@
-;;; evil-mc-command-execute.el --- Execute commands for every fake cursor
+;;; evil-mc-command-execute.el --- Execute commands for every fake cursor -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-command-record.el
+++ b/evil-mc-command-record.el
@@ -1,4 +1,4 @@
-;;; evil-mc-command-record.el --- Record info for the currently running command
+;;; evil-mc-command-record.el --- Record info for the currently running command -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-common.el
+++ b/evil-mc-common.el
@@ -1,4 +1,4 @@
-;;; evil-mc-common.el --- Common functions
+;;; evil-mc-common.el --- Common functions -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -1,4 +1,4 @@
-;;; evil-mc-cursor-make.el --- Fake cursor creation and deletion
+;;; evil-mc-cursor-make.el --- Fake cursor creation and deletion -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-cursor-state.el
+++ b/evil-mc-cursor-state.el
@@ -1,4 +1,4 @@
-;;; evil-mc-cursor-state.el --- State saved for each fake cursor
+;;; evil-mc-cursor-state.el --- State saved for each fake cursor -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -1,4 +1,4 @@
-;;; evil-mc-known-commands.el --- A list of supported commands and their handlers
+;;; evil-mc-known-commands.el --- A list of supported commands and their handlers -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-region.el
+++ b/evil-mc-region.el
@@ -1,4 +1,4 @@
-;;; evil-mc-region.el --- Visual region
+;;; evil-mc-region.el --- Visual region -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-scratch.el
+++ b/evil-mc-scratch.el
@@ -1,4 +1,4 @@
-;;; evil-mc-scratch.el --- Functions used during development
+;;; evil-mc-scratch.el --- Functions used during development -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-setup.el
+++ b/evil-mc-setup.el
@@ -1,4 +1,4 @@
-;;; evil-mc-setup.el --- Sample setup for evil-mc
+;;; evil-mc-setup.el --- Sample setup for evil-mc -*- lexical-binding: nil -*-
 
 ;;; Commentary: Example of setting up evil-mc
 

--- a/evil-mc-undo.el
+++ b/evil-mc-undo.el
@@ -1,4 +1,4 @@
-;;; evil-mc-undo.el --- Undo related functions
+;;; evil-mc-undo.el --- Undo related functions -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -1,4 +1,4 @@
-;;; evil-mc-vars.el --- Variables for evil-mc
+;;; evil-mc-vars.el --- Variables for evil-mc -*- lexical-binding: nil -*-
 
 ;;; Commentary:
 

--- a/evil-mc.el
+++ b/evil-mc.el
@@ -1,4 +1,4 @@
-;;; evil-mc.el --- Multiple cursors for evil-mode
+;;; evil-mc.el --- Multiple cursors for evil-mode -*- lexical-binding: nil -*-
 
 ;; Copyright © 2015-2016 Gabriel Adomnicai <gabesoft@gmail.com>
 


### PR DESCRIPTION
This package breaks when lexical-binding is enabled, so we need to set it to nil explicitly in all files to avoid future breakage and to appease the byte compiler.