### PR TITLE
enable lexical binding

### DIFF
--- a/evil-mc-command-record.el
+++ b/evil-mc-command-record.el
@@ -1,4 +1,4 @@
-;;; evil-mc-command-record.el --- Record info for the currently running command
+;;; evil-mc-command-record.el --- Record info for the currently running command -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-common.el
+++ b/evil-mc-common.el
@@ -1,4 +1,4 @@
-;;; evil-mc-common.el --- Common functions
+;;; evil-mc-common.el --- Common functions -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-cursor-make.el
+++ b/evil-mc-cursor-make.el
@@ -1,4 +1,4 @@
-;;; evil-mc-cursor-make.el --- Fake cursor creation and deletion
+;;; evil-mc-cursor-make.el --- Fake cursor creation and deletion -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-cursor-state.el
+++ b/evil-mc-cursor-state.el
@@ -1,4 +1,4 @@
-;;; evil-mc-cursor-state.el --- State saved for each fake cursor
+;;; evil-mc-cursor-state.el --- State saved for each fake cursor -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-known-commands.el
+++ b/evil-mc-known-commands.el
@@ -1,4 +1,4 @@
-;;; evil-mc-known-commands.el --- A list of supported commands and their handlers
+;;; evil-mc-known-commands.el --- A list of supported commands and their handlers -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-region.el
+++ b/evil-mc-region.el
@@ -1,4 +1,4 @@
-;;; evil-mc-region.el --- Visual region
+;;; evil-mc-region.el --- Visual region -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 
@@ -104,8 +104,6 @@ set to the specified values."
   "Make an overlay for a visual region of type line from MARK to POINT."
   (let* ((start-pos (if (< mark point) mark point))
          (end-pos (if (< mark point) point mark))
-         (start-line (line-number-at-pos start-pos))
-         (end-line (line-number-at-pos end-pos))
          (start (evil-mc-get-pos-at-bol start-pos))
          (end (1+ (evil-mc-get-pos-at-eol end-pos)))
          (overlay (evil-mc-region-overlay start end)))

--- a/evil-mc-scratch.el
+++ b/evil-mc-scratch.el
@@ -1,4 +1,4 @@
-;;; evil-mc-scratch.el --- Functions used during development
+;;; evil-mc-scratch.el --- Functions used during development -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-setup.el
+++ b/evil-mc-setup.el
@@ -1,4 +1,4 @@
-;;; evil-mc-setup.el --- Sample setup for evil-mc
+;;; evil-mc-setup.el --- Sample setup for evil-mc -*- lexical-binding: t; -*-
 
 ;;; Commentary: Example of setting up evil-mc
 

--- a/evil-mc-undo.el
+++ b/evil-mc-undo.el
@@ -1,4 +1,4 @@
-;;; evil-mc-undo.el --- Undo related functions
+;;; evil-mc-undo.el --- Undo related functions -*- lexical-binding: nil; -*-
 
 ;;; Commentary:
 

--- a/evil-mc-vars.el
+++ b/evil-mc-vars.el
@@ -1,4 +1,4 @@
-;;; evil-mc-vars.el --- Variables for evil-mc
+;;; evil-mc-vars.el --- Variables for evil-mc -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/evil-mc.el
+++ b/evil-mc.el
@@ -1,4 +1,4 @@
-;;; evil-mc.el --- Multiple cursors for evil-mode
+;;; evil-mc.el --- Multiple cursors for evil-mode -*- lexical-binding: nil; -*-
 
 ;; Copyright © 2015-2016 Gabriel Adomnicai <gabesoft@gmail.com>
 
@@ -45,7 +45,7 @@
 (defun evil-mc-active-mode-line (prefix)
   "Get the mode-line text to be displayed when there are active cursors"
   (let ((mode-line-text
-         (concat mode-line-text-prefix
+         (concat prefix
                  (when (and (evil-mc-frozen-p)
                             evil-mc-mode-line-text-paused)
                    "(paused)")


### PR DESCRIPTION
This PR enables lexical binding in this package and fixes the bugs that arose when doing so. This is important because in the future, lexical binding may become the default for Emacs so this prevents problems from arising in the future.